### PR TITLE
docs: add pre-built Ubuntu/Debian package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Inspired by [nginx-unzip-module](https://github.com/youzee/nginx-unzip-module).
 
 ## Pre-built Packages (Ubuntu / Debian)
 
-Pre-built packages for this module are freely available from the GetPageSpeed repository:
+Pre-built packages for this module are freely available from the GetPageSpeed repository.
+
+> **Note:** GetPageSpeed is a third-party repository and is not affiliated with the author of this module.
 
 ```bash
 # Install the repository keyring

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 This [nginx](https://nginx.org/) module can serve static file content directly from tar archives.
 Inspired by [nginx-unzip-module](https://github.com/youzee/nginx-unzip-module).
 
+## Pre-built Packages (Ubuntu / Debian)
+
+Pre-built packages for this module are freely available from the GetPageSpeed repository:
+
+```bash
+# Install the repository keyring
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://extras.getpagespeed.com/deb-archive-keyring.gpg \
+  | sudo tee /etc/apt/keyrings/getpagespeed.gpg >/dev/null
+
+# Add the repository (Ubuntu example - replace 'ubuntu' and 'jammy' for your distro)
+echo "deb [signed-by=/etc/apt/keyrings/getpagespeed.gpg] https://extras.getpagespeed.com/ubuntu jammy main" \
+  | sudo tee /etc/apt/sources.list.d/getpagespeed-extras.list
+
+# Install nginx and the module
+sudo apt-get update
+sudo apt-get install nginx nginx-module-untar
+```
+
+The module is automatically enabled after installation. Supported distributions include Debian 12/13 and Ubuntu 20.04/22.04/24.04 (both amd64 and arm64). See [the complete setup instructions](https://apt-nginx-extras.getpagespeed.com/apt-setup/).
+
 ## Features
 * Zero-copy: outputs content directly from archive file (no temporary files)
 * Caching parsed archive file entries: reduce archive scan-search time


### PR DESCRIPTION
## Summary

- Added documentation for installing pre-built packages from the GetPageSpeed APT repository
- Covers Ubuntu 20.04/22.04/24.04 and Debian 12/13 (amd64 and arm64)

## Details

Pre-built dynamic module packages are freely available, making installation much simpler for Ubuntu/Debian users who don't want to compile from source.

The module is automatically enabled after installation via symlinks in `/etc/nginx/modules-enabled/`.